### PR TITLE
mayfes2022: Update Compile-time TypeScript

### DIFF
--- a/boxes/compile-time-typescript/Dockerfile
+++ b/boxes/compile-time-typescript/Dockerfile
@@ -5,9 +5,7 @@ ENV BUILD_PACKAGES="npm" \
 
 RUN apk add --update $BUILD_PACKAGES $RUNTIME_PACKAGES && \
     rm /bin/node && \
-    git clone --depth 1 https://github.com/n4o847/compile-time-typescript.git -b v1.1.1 ~/compile-time-typescript && \
-    cd ~/compile-time-typescript && \
-    npm install && \
+    npm install -g compile-time-typescript@1.1.1 \
     apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* && \
     ln -s /bin/script /bin/compile-time-typescript

--- a/boxes/compile-time-typescript/Dockerfile
+++ b/boxes/compile-time-typescript/Dockerfile
@@ -5,7 +5,7 @@ ENV BUILD_PACKAGES="npm" \
 
 RUN apk add --update $BUILD_PACKAGES $RUNTIME_PACKAGES && \
     rm /bin/node && \
-    npm install -g compile-time-typescript@1.1.1 && \
+    npm install -g compile-time-typescript@1.4.0 && \
     apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* && \
     ln -s /bin/script /bin/compile-time-typescript

--- a/boxes/compile-time-typescript/Dockerfile
+++ b/boxes/compile-time-typescript/Dockerfile
@@ -5,7 +5,7 @@ ENV BUILD_PACKAGES="npm" \
 
 RUN apk add --update $BUILD_PACKAGES $RUNTIME_PACKAGES && \
     rm /bin/node && \
-    npm install -g compile-time-typescript@1.1.1 \
+    npm install -g compile-time-typescript@1.1.1 && \
     apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* && \
     ln -s /bin/script /bin/compile-time-typescript

--- a/boxes/compile-time-typescript/script
+++ b/boxes/compile-time-typescript/script
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-cat - | ctts "$1"
+# All CTTS code should have prefix .ts
+infile=$(realpath "$1")
+ln -sf "$infile" /tmp/code.ts
+
+cat - | ctts /tmp/code.ts
+
+rm /tmp/code.ts

--- a/boxes/compile-time-typescript/script
+++ b/boxes/compile-time-typescript/script
@@ -2,7 +2,7 @@
 
 ctts --version 1>&2
 
-# All CTTS code should have prefix .ts
+# All CTTS code should have suffix .ts
 infile=$(realpath "$1")
 ln -sf "$infile" /tmp/code.ts
 

--- a/boxes/compile-time-typescript/script
+++ b/boxes/compile-time-typescript/script
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+ctts --version 1>&2
+
 # All CTTS code should have prefix .ts
 infile=$(realpath "$1")
 ln -sf "$infile" /tmp/code.ts

--- a/boxes/compile-time-typescript/script
+++ b/boxes/compile-time-typescript/script
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cd ~/compile-time-typescript && (cat - | ./node_modules/.bin/ts-node src "$1")
+cat - | ctts "$1"


### PR DESCRIPTION
compile-time-typescript 1.1.1 (with typescript 4.1.2)
から
compile-time-typescript 1.4.0 (with typescript 4.7.0-beta)
に変更。

拡張子 .ts がないと動かせないのは罠だった。