### PR TITLE
mayfes2022: Update プロデル

### DIFF
--- a/boxes/produire/Dockerfile
+++ b/boxes/produire/Dockerfile
@@ -2,9 +2,9 @@ FROM esolang/csharp
 
 RUN cd /tmp && \
     apk add --update libgdiplus --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
-    curl https://rdr.utopiat.net/files/mono//produire-mono-1.6.965.tar.gz -LO && \
+    curl https://rdr.utopiat.net/files/mono//produire-mono-1.8.1131.tar.gz -LO && \
     mkdir -p ~/produire && \
-    tar xf produire-mono-1.6.965.tar.gz -C ~/produire && \
+    tar xf produire-mono-1.8.1131.tar.gz -C ~/produire && \
     rm -rf /var/cache/apk/* /tmp/* && \
     ln -s /bin/script /bin/produire && \
     rm /bin/csharp


### PR DESCRIPTION
プロデル mono 最新版を作者に修正してもらうことで更新。

1.6.965 → 1.8.1131 になります。

↓ 会話の経緯
- https://rdr.utopiat.net/cgi/bbs2/wforum-rdr.cgi?mode=read&no=2152&reno=no&oya=2152&page=0#2152
- https://rdr.utopiat.net/cgi/bbs2/wforum-rdr.cgi?mode=read&no=2153&reno=2152&oya=2152&page=0#2153
- https://rdr.utopiat.net/cgi/bbs2/wforum-rdr.cgi?mode=read&no=2154&reno=2153&oya=2152&page=0#2154